### PR TITLE
Setup global theme and support (rtl/ltr,  fa/en,  dark/light) 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.7",
+        "@mui/stylis-plugin-rtl": "^7.3.8",
         "@tailwindcss/vite": "^4.1.18",
         "i18next": "^25.8.5",
         "i18next-browser-languagedetector": "^8.2.0",
@@ -1298,6 +1299,26 @@
         }
       }
     },
+    "node_modules/@mui/stylis-plugin-rtl": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@mui/stylis-plugin-rtl/-/stylis-plugin-rtl-7.3.8.tgz",
+      "integrity": "sha512-X5e+C6Nw0+0Mwl8RoQcvbT6gPOL5snilg7dDy04FZySE7/fyagT2H1gYsGDUamAo0h6GcNFzYkMZBod0RGlnMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "cssjanus": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "stylis": "4.x"
+      }
+    },
     "node_modules/@mui/system": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.7.tgz",
@@ -2399,6 +2420,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssjanus": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssjanus/-/cssjanus-2.3.0.tgz",
+      "integrity": "sha512-ZZXXn51SnxRxAZ6fdY7mBDPmA4OZd83q/J9Gdqz3YmE9TUq+9tZl+tdOnCi7PpNygI6PEkehj9rgifv5+W8a5A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/csstype": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
+    "@mui/stylis-plugin-rtl": "^7.3.8",
     "@tailwindcss/vite": "^4.1.18",
     "i18next": "^25.8.5",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,35 @@
+import { useState} from "react"
+import AppThemeProvider from "./providers/AppThemeProvider"
+import AppRoutes from "./routes/AppRoutes"
+import "./i18n"
 
 function App() {
 
+  // we can add this logic of dark mode and language to context/settingsContext because these are globle and shoud be in a context
+
+  const saveMode = localStorage.getItem("appMode") || "light"
+  
+  const [mode, setMode] = useState(saveMode)
+
+  const toggleMode = () => {
+    setMode(prev => {
+      const newMode = prev === "light" ? "dark" : "light"
+      localStorage.setItem("appMode", newMode)
+      return newMode
+    })
+  }
+
+  const toggleLanguage = () => {
+  const newLang = i18n.language === "fa" ? "en" : "fa"
+  i18n.changeLanguage(newLang)
+  localStorage.setItem("appLanguage", newLang)
+  }
+
   return (
     <>
-     
+     <AppThemeProvider mode={mode}>
+        <AppRoutes />
+     </AppThemeProvider>
     </>
   )
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,16 @@
+import i18n from "il8next"
+import { initReactI18next } from "react-i18next"
+
+const savedLanguage = localStorage.getItem("appLanguage") || "en"
+
+i18n.use(initReactI18next).init({
+    resources: {
+        en: { translation: { welcome: "My Goal" } },
+        fa: { translation: { welcome: "مسیر من" } },
+    },
+    lng: savedLanguage,
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+})
+
+export default il8n;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,4 +1,4 @@
-import i18n from "il8next"
+import i18n from "i18next"
 import { initReactI18next } from "react-i18next"
 
 const savedLanguage = localStorage.getItem("appLanguage") || "en"
@@ -13,4 +13,4 @@ i18n.use(initReactI18next).init({
     interpolation: { escapeValue: false },
 })
 
-export default il8n;
+export default i18n;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import { BrowserRouter } from 'react-router'
+import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/providers/AppThemeProvider.jsx
+++ b/src/providers/AppThemeProvider.jsx
@@ -1,0 +1,26 @@
+// src/providers/AppThemeProvider.jsx
+import { ThemeProvider, useTheme } from "@mui/material/styles";
+import { CacheProvider } from "@emotion/react";
+import { getTheme } from "../theme/theme";
+import { cacheRtl, cacheLtr } from "../theme/cache";
+import { useTranslation } from "react-i18next";
+import { useEffect } from "react";
+
+export default function AppThemeProvider({ children, mode }) {
+  const { i18n } = useTranslation()
+  const direction = i18n.language === "fa" ? "rtl" : "ltr"
+
+  const theme = getTheme(mode, direction)
+  const cache = direction === "rtl" ? cacheRtl : cacheLtr
+
+  useEffect(() => {
+    document.documentElement.dir = direction
+    document.body.dir = direction
+  }, [direction])
+
+  return (
+    <CacheProvider value={cache}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </CacheProvider>
+  )
+}

--- a/src/theme/cache.js
+++ b/src/theme/cache.js
@@ -1,0 +1,13 @@
+import createCache from "@emotion/cache"
+import { prefixer } from "stylis"
+import rtlPlugin from "@mui/stylis-plugin-rtl"
+
+export const cacheRtl = createCache({
+    key: "muirtl",
+    stylisPlugins: [prefixer, rtlPlugin],
+})
+
+export const cacheLtr = createCache({
+    key: "muiltr",
+    stylisPlugins: [prefixer],
+})

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,0 +1,41 @@
+
+import { createTheme } from "@mui/material/styles";
+
+export const getTheme = (mode, direction) => {
+  return createTheme({
+    direction,
+
+    palette: {
+      mode,
+      primary: {
+        main: "#1976d2"
+      },
+      background: {
+        default: mode === "light" ? "#f6f7fb" : "#0b1220",
+        Paper: mode === "light" ? "#ffffff" : "#0f172a",
+      },
+    },
+
+    shape: { borderRadius: 12 },
+    spacing: 8,
+
+    typography: {
+      fontFamily: direction === "rtl" ? "Vazirmatn, sans-serif" : ["Inter", "system-ui", "Arial", "sans-serif"].join(","),
+    },
+
+    components: {
+      MuiButton: {
+        styleOverrides: { root: { borderRadius: 12 } },
+      },
+      MuiPaper: {
+        styleOverrides: { root: { borderRadius: 12 } },
+      },
+      MuiCard: {
+        styleOverrides: { root: { borderRedius: 12 } },
+      },
+      MuiSvgIcon: {
+        styleOverrides: { root: { color: mode === "light" ? "#1976d2" : "#90caf9", }}
+      }
+    },
+  });
+};


### PR DESCRIPTION
This PR adds the global AppThemeProvider for the app, handling:
- Light and dark mode themes
- Persian/English language toggle
- Automatic RTL/LTR direction switching
- i18n initialization
- 
closes #7
