### PR TITLE
feat(theme): implement dark mode with settings page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,18 +7,6 @@ function App() {
 
   // we can add this logic of dark mode and language to context/settingsContext because these are globle and shoud be in a context
 
-  const saveMode = localStorage.getItem("appMode") || "light"
-  
-  const [mode, setMode] = useState(saveMode)
-
-  const toggleMode = () => {
-    setMode(prev => {
-      const newMode = prev === "light" ? "dark" : "light"
-      localStorage.setItem("appMode", newMode)
-      return newMode
-    })
-  }
-
   const toggleLanguage = () => {
   const newLang = i18n.language === "fa" ? "en" : "fa"
   i18n.changeLanguage(newLang)
@@ -27,7 +15,7 @@ function App() {
 
   return (
     <>
-     <AppThemeProvider mode={mode}>
+     <AppThemeProvider>
         <AppRoutes />
      </AppThemeProvider>
     </>

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useCallback, useMemo, useState } from "react"
+
+export const ThemeContext =  createContext()
+
+export function ThemeProvider({ children }) {
+
+    const saveMode = localStorage.getItem("appMode") || "light"
+    const [mode, setMode] = useState(saveMode)
+
+    const toggleMode = useCallback(() => {
+        setMode(prev => {
+            const newMode = prev === "light" ? "dark" : "light"
+            localStorage.setItem("appMode", newMode)
+            return newMode
+        })
+    }, [])
+
+    const value = useMemo(() => ({
+        mode,
+        toggleMode
+    }), [mode, toggleMode])
+
+    return (
+        <ThemeContext.Provider value={value}>
+            {children}
+        </ThemeContext.Provider>
+    )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,15 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
-import { BrowserRouter } from 'react-router-dom'
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import { BrowserRouter } from "react-router-dom"
+import App from "./App"
+import { ThemeProvider } from "./context/ThemeContext"
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-       <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </BrowserRouter>
-  </StrictMode>,
+  </StrictMode>
 )

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,5 +1,52 @@
-export default function Settings(){
-    return(
-        <div>Settings</div>
-    )
+import { useContext } from "react"
+import { ThemeContext } from "../context/ThemeContext"
+
+import { Box, Divider, Paper, Stack, Switch, Typography } from "@mui/material"
+
+export default function Settings() {
+  const { mode, toggleMode } = useContext(ThemeContext)
+  const isDark = mode === "dark"
+
+  return (
+    <Box
+      sx={{
+        display: "flex", flexGrow: 1,
+        justifyContent: "center", p: 4,
+        mt:10
+      }}
+    >
+      <Paper
+        elevation={3}
+        sx={{
+          maxWidth: 600, width: "100%",
+          p: 4
+        }}
+      >
+        <Stack spacing={3}>
+          <Typography variant="h5">
+            تنظیمات
+          </Typography>
+
+          <Divider />
+
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            <Box>
+              <Typography variant="subtitle1">
+                {isDark ? "حالت روشن" : "حالت تاریک"}
+              </Typography>
+            </Box>
+
+            <Switch
+              checked={isDark}
+              onChange={toggleMode}
+            />
+          </Stack>
+        </Stack>
+      </Paper>
+    </Box>
+  )
 }

--- a/src/providers/AppThemeProvider.jsx
+++ b/src/providers/AppThemeProvider.jsx
@@ -1,12 +1,15 @@
-// src/providers/AppThemeProvider.jsx
-import { ThemeProvider, useTheme } from "@mui/material/styles";
-import { CacheProvider } from "@emotion/react";
-import { getTheme } from "../theme/theme";
-import { cacheRtl, cacheLtr } from "../theme/cache";
-import { useTranslation } from "react-i18next";
-import { useEffect } from "react";
+import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles"
+import { CacheProvider } from "@emotion/react"
+import { getTheme } from "../theme/theme"
+import { cacheRtl, cacheLtr } from "../theme/cache"
+import { useTranslation } from "react-i18next"
+import { useEffect, useContext } from "react"
+import { ThemeContext } from "../context/ThemeContext"
+import CssBaseline from "@mui/material/CssBaseline"
 
-export default function AppThemeProvider({ children, mode }) {
+export default function AppThemeProvider({ children }) {
+  const { mode } = useContext(ThemeContext)
+
   const { i18n } = useTranslation()
   const direction = i18n.language === "fa" ? "rtl" : "ltr"
 
@@ -20,7 +23,10 @@ export default function AppThemeProvider({ children, mode }) {
 
   return (
     <CacheProvider value={cache}>
-      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+      <MuiThemeProvider theme={theme}>
+         <CssBaseline />
+        {children}
+      </MuiThemeProvider>
     </CacheProvider>
   )
 }


### PR DESCRIPTION
In this PR I added dark mode support to the project.

- The theme logic was previously inside App.jsx, but I moved it into a separate ThemeContext to keep things cleaner and easier to manage. Now the theme state lives in one place instead of being handled inside the main app component.

- The selected mode is stored in localStorage, so it stays the same after a page refresh.

- AppThemeProvider now reads the mode from the context and builds the MUI theme based on it. I also added CssBaseline to make sure the background and base styles work correctly in both light and dark mode.

- The app is wrapped with ThemeProvider in main.jsx.

There’s also a simple Settings page where the user can toggle between light and dark mode.