### PR TITLE
feat: Create goalsContext and ubdate goalsForm

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,16 +5,19 @@ import "./index.css"
 import "./i18n/index.js"
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { GoalsProvider } from "./context/GoalsContext.jsx";
 
 function App() {
 
   return (
     <>
-      <LocalizationProvider dateAdapter={AdapterDayjs}>
-        <AppThemeProvider>
-          <AppRoutes />
-        </AppThemeProvider>
-      </LocalizationProvider>
+      <GoalsProvider>
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <AppThemeProvider>
+            <AppRoutes />
+          </AppThemeProvider>
+        </LocalizationProvider>
+      </GoalsProvider>
     </>
   )
 }

--- a/src/components/forms/GoalForm.jsx
+++ b/src/components/forms/GoalForm.jsx
@@ -22,11 +22,15 @@ import { useState } from "react"
 export default function GoalForm({ defaultValues }) {
   const [successOpen, setSuccessOpen] = useState(false)
   const { t } = useTranslation("createGoal")
-
   const { addGoal } = useGoals()
 
+  const goalTypeOptions = t("goalTypeOptions", { returnObjects: true })
+  const goalCategoryOptions = t("goalCategoryOptions", { returnObjects: true })
+
+  const schema = goalSchema(goalTypeOptions, goalCategoryOptions)
+
   const { control, handleSubmit , reset, formState: { isValid } } = useForm({
-    resolver: yupResolver(goalSchema),
+    resolver: yupResolver(schema),
     defaultValues: defaultValues || {
       title: "",
       description: "",
@@ -47,9 +51,6 @@ export default function GoalForm({ defaultValues }) {
     reset()
     setSuccessOpen(true)
   };
-
-  const goalTypeOptions = t("goalTypeOptions", { returnObjects: true })
-  const goalCategoryOptions = t("goalCategoryOptions", { returnObjects: true })
 
   return (
     <Box
@@ -78,7 +79,7 @@ export default function GoalForm({ defaultValues }) {
             severity="success"
             variant="filled"
           >
-            Goal created successfully
+            {t("messages.goalCreated")}
           </Alert >
         </Snackbar>
 

--- a/src/components/forms/GoalForm.jsx
+++ b/src/components/forms/GoalForm.jsx
@@ -14,11 +14,18 @@ import { goalSchema } from "../../validations/goalSchema"
 import FormTextField from "./FormTextField"
 import FormSelectField from "./FormSelectField"
 import FormDatePicker from "./FormDatePicker"
+import { useGoals } from "../../context/GoalsContext"
+import { Snackbar, Alert } from "@mui/material"
+import { useState } from "react"
+
 
 export default function GoalForm({ defaultValues }) {
+  const [successOpen, setSuccessOpen] = useState(false)
   const { t } = useTranslation("createGoal")
 
-  const { control, handleSubmit } = useForm({
+  const { addGoal } = useGoals()
+
+  const { control, handleSubmit , reset, formState: { isValid } } = useForm({
     resolver: yupResolver(goalSchema),
     defaultValues: defaultValues || {
       title: "",
@@ -29,10 +36,16 @@ export default function GoalForm({ defaultValues }) {
       startDate: null,
       endDate: null,
     },
+    mode: "onTouched",
+    reValidateMode: "onChange"
   });
 
   const onSubmit = (data) => {
-    console.log(data);
+      console.log("FORM DATA:", data)
+    addGoal(data);
+
+    reset()
+    setSuccessOpen(true)
   };
 
   const goalTypeOptions = t("goalTypeOptions", { returnObjects: true })
@@ -41,7 +54,7 @@ export default function GoalForm({ defaultValues }) {
   return (
     <Box
       sx={{
-        Height: "100%",
+        height: "100%",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -56,6 +69,19 @@ export default function GoalForm({ defaultValues }) {
           p: { xs: 2, sm: 3, md: 5},
         }}
       >
+        <Snackbar
+          open={successOpen}
+          autoHideDuration={3000}
+          onClose={() => setSuccessOpen(false)}
+        >
+          <Alert 
+            severity="success"
+            variant="filled"
+          >
+            Goal created successfully
+          </Alert >
+        </Snackbar>
+
         <Box textAlign="center" mb={4}>
           <Typography variant="h5">{t("title")}</Typography>
           <Typography variant="body2" color="text.secondary" mt={1}>
@@ -138,6 +164,7 @@ export default function GoalForm({ defaultValues }) {
                 type="submit"
                 fullWidth
                 variant="contained"
+                disabled={!isValid}
                 startIcon={<CreateNewFolderIcon fontSize="small"  />}
                 sx={{
                   py: 1.4,

--- a/src/context/GoalsContext.jsx
+++ b/src/context/GoalsContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useEffect, useState } from "react"
+
+ const GoalsContext = createContext()
+
+export function GoalsProvider({ children }) {
+    const [goals, setGoals] = useState(() => {
+        const saved = localStorage.getItem("goals")
+        return saved ? JSON.parse(saved) : []
+    })
+
+    useEffect(() => {
+        localStorage.setItem("goals", JSON.stringify(goals))
+    }, [goals])
+
+    const addGoal = (goal) => {
+        setGoals((prev) => [...prev, {id: Date.now(), ...goal}])
+    }
+
+    const removeGoal = (id) => {
+        setGoals((prev) => prev.filter(goal => goal.id !== id))
+    }
+
+    return (
+        <GoalsContext.Provider value={{ goals, addGoal, removeGoal }}>
+            {children}
+        </GoalsContext.Provider>
+    )
+}
+
+export const useGoals = () => useContext(GoalsContext)

--- a/src/context/GoalsContext.jsx
+++ b/src/context/GoalsContext.jsx
@@ -1,30 +1,83 @@
+
 import { createContext, useContext, useEffect, useState } from "react"
 
- const GoalsContext = createContext()
+const GoalsContext = createContext()
 
 export function GoalsProvider({ children }) {
-    const [goals, setGoals] = useState(() => {
-        const saved = localStorage.getItem("goals")
-        return saved ? JSON.parse(saved) : []
-    })
 
-    useEffect(() => {
-        localStorage.setItem("goals", JSON.stringify(goals))
-    }, [goals])
+  const [goals, setGoals] = useState(() => {
+    const saved = localStorage.getItem("goals")
+    return saved ? JSON.parse(saved) : []
+  })
 
-    const addGoal = (goal) => {
-        setGoals((prev) => [...prev, {id: Date.now(), ...goal}])
-    }
+  useEffect(() => {
+    localStorage.setItem("goals", JSON.stringify(goals))
+  }, [goals])
 
-    const removeGoal = (id) => {
-        setGoals((prev) => prev.filter(goal => goal.id !== id))
-    }
+ 
+  const addGoal = (goal) => {
+    setGoals((prev) => [...prev, { 
+      id: Date.now(), 
+      progress: 0, 
+      status: "active", 
+      logs: [], 
+      createdAt: new Date().toISOString(), 
+      updatedAt: new Date().toISOString(), 
+      ...goal 
+    }])
+  }
 
-    return (
-        <GoalsContext.Provider value={{ goals, addGoal, removeGoal }}>
-            {children}
-        </GoalsContext.Provider>
-    )
+  const removeGoal = (id) => {
+    setGoals((prev) => prev.filter(goal => goal.id !== id))
+  }
+
+  const updateGoal = (id, updatedData) => {
+    setGoals((prev) => prev.map(goal => 
+      goal.id === id ? { ...goal, ...updatedData, updatedAt: new Date().toISOString() } : goal
+    ))
+  }
+
+
+  const addProgress = (id, amount = 1) => {
+    setGoals((prev) => prev.map(goal => {
+      if (goal.id === id) {
+        const newProgress = goal.progress + amount
+        const updatedGoal = {
+          ...goal,
+          progress: newProgress,
+          logs: [...goal.logs, { date: new Date().toISOString(), amount }],
+          updatedAt: new Date().toISOString()
+        }
+     
+        if (goal.target && newProgress >= goal.target) {
+          updatedGoal.status = "completed"
+        }
+        return updatedGoal
+      }
+      return goal
+    }))
+  }
+
+ 
+  const markComplete = (id) => {
+    setGoals((prev) => prev.map(goal => 
+      goal.id === id ? { ...goal, status: "completed", updatedAt: new Date().toISOString() } : goal
+    ))
+  }
+
+  return (
+    <GoalsContext.Provider value={{
+      goals,
+      addGoal,
+      removeGoal,
+      updateGoal,
+      addProgress,
+      markComplete,
+      setGoals
+    }}>
+      {children}
+    </GoalsContext.Provider>
+  )
 }
 
 export const useGoals = () => useContext(GoalsContext)

--- a/src/i18n/locales/en/createGoal.json
+++ b/src/i18n/locales/en/createGoal.json
@@ -31,5 +31,9 @@
 
   "buttons": {
     "create": "Create Goal"
+  },
+
+  "messages": {
+    "goalCreated": "Goal created successfully"
   }
 }

--- a/src/i18n/locales/fa/createGoal.json
+++ b/src/i18n/locales/fa/createGoal.json
@@ -31,5 +31,9 @@
 
   "buttons": {
     "create": "ایجاد هدف"
+  },
+
+  "messages": {
+    "goalCreated": "هدف با موفقیت ایجاد شد"
   }
 }

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -40,10 +40,6 @@ export const getTheme = (mode, direction) => {
           root: { 
             borderRadius: 12 
           },
-          contained: {
-            fontSize: "1.3rem",
-            fontWeight: 500,
-          } 
         },
       },
 

--- a/src/validations/goalSchema.js
+++ b/src/validations/goalSchema.js
@@ -1,6 +1,8 @@
+
 import * as yup from "yup";
 
-export const goalSchema = yup.object({
+export const goalSchema = (goalTypeOptions, goalCategoryOptions) =>
+  yup.object({
     title: yup
         .string()
         .trim()
@@ -8,18 +10,22 @@ export const goalSchema = yup.object({
         .min(3, "Title must be at least 3 characters")
         .max(100, "Title must not be more that 100 characters")
     ,
-    
     goalCategory: yup
         .string()
-        .required("Category is reqiured")
-        .oneOf(["Health", "Study", "Work", "Personal"], "Other")
-    ,
-
+        .nullable()
+        .required("Type is required")
+        .oneOf(
+            goalCategoryOptions.map(opt => opt.value), 
+            "Invalid type"
+        ),
     goalType: yup
         .string()
+        .nullable()
         .required("Type is required")
-        .oneOf(["Daily", "Count-based", "Time-based"], "Other")
-    ,
+        .oneOf(
+            goalTypeOptions.map(opt => opt.value), 
+            "Invalid type"
+        ),
 
     target: yup
         .number()
@@ -33,7 +39,7 @@ export const goalSchema = yup.object({
         .required("Start date is required")
     ,
 
-    endDate: yup 
+    endDate: yup
         .date()
         .nullable()
         .notRequired()


### PR DESCRIPTION
In this branch 
- I Added a GoalsContext in the context/ folder to save goals in localStorage.
- Updated GoalForm so it now uses onTouched + reValidateMode, resets after submission, shows a success snackbar, and disables the submit button until the form is valid.
- Removed unnecessary contained style from Theme

Now goals data is managed in GoalsContext with localStorage.
Just use useGoals() to access goals.

closes #55