### PR TITLE
Add Edit Goal Page

### DIFF
--- a/src/components/GoalCard.jsx
+++ b/src/components/GoalCard.jsx
@@ -149,7 +149,7 @@ export default function GoalCard({
               color="primary"
               onClick={(e) => {
                 e.stopPropagation();
-                onEdit();
+                onEdit(id);
               }}
             >
               {t("button.edit")}

--- a/src/components/GoalList.jsx
+++ b/src/components/GoalList.jsx
@@ -29,6 +29,7 @@ export default function GoalList({
       <Stack spacing={2}>
         {goals.map((goal) => (
           <GoalCard
+            key={goal.id}
             id={goal.id}
             title={goal.title}
             titleKey={goal.titleKey}

--- a/src/components/forms/FormDatePicker.jsx
+++ b/src/components/forms/FormDatePicker.jsx
@@ -1,26 +1,30 @@
 import { Controller } from "react-hook-form";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import dayjs from "dayjs";
 
 export default function FormDatePicker({ name, control, label, ...props }) {
   return (
     <Controller
       name={name}
       control={control}
-      render={({ field, fieldState }) => (
-        <DatePicker
-          label={label}
-          value={field.value}
-          onChange={(newValue) => field.onChange(newValue)}
-          slotProps={{
-            textField: {
-              fullWidth: true,
-              error: !!fieldState.error,
-              helperText: fieldState.error?.message,
-            },
-          }}
-          {...props}
-        />
-      )}
+      render={({ field, fieldState }) => {
+        const value = field.value ? dayjs(field.value) : null; // تبدیل به dayjs
+        return (
+          <DatePicker
+            label={label}
+            value={value}
+            onChange={(newValue) => field.onChange(newValue ? newValue.toISOString() : null)} // ذخیره به صورت ISO
+            slotProps={{
+              textField: {
+                fullWidth: true,
+                error: !!fieldState.error,
+                helperText: fieldState.error?.message,
+              },
+            }}
+            {...props}
+          />
+        );
+      }}
     />
   );
 }

--- a/src/components/forms/GoalForm.jsx
+++ b/src/components/forms/GoalForm.jsx
@@ -1,5 +1,6 @@
 import { useForm } from "react-hook-form"
 import { yupResolver } from "@hookform/resolvers/yup"
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next"
 import { Paper, Box, Button, Grid, Typography } from "@mui/material"
 
@@ -9,6 +10,7 @@ import MergeTypeIcon from "@mui/icons-material/MergeType"
 import CategoryIcon from "@mui/icons-material/Category"
 import DescriptionIcon from "@mui/icons-material/Description"
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
+import EditIcon from "@mui/icons-material/Edit"
 
 import { goalSchema } from "../../validations/goalSchema"
 import FormTextField from "./FormTextField"
@@ -20,9 +22,11 @@ import { useState } from "react"
 
 
 export default function GoalForm({ defaultValues }) {
+  const navigate = useNavigate();
   const [successOpen, setSuccessOpen] = useState(false)
+  const [successMessage, setSuccessMessage] = useState("")
   const { t } = useTranslation("createGoal")
-  const { addGoal } = useGoals()
+  const { addGoal, updateGoal } = useGoals()
 
   const goalTypeOptions = t("goalTypeOptions", { returnObjects: true })
   const goalCategoryOptions = t("goalCategoryOptions", { returnObjects: true })
@@ -45,8 +49,16 @@ export default function GoalForm({ defaultValues }) {
   });
 
   const onSubmit = (data) => {
-      console.log("FORM DATA:", data)
-    addGoal(data);
+
+    if(defaultValues){
+       updateGoal(defaultValues.id , data)
+       setSuccessMessage(t("messages.goalUpdated"))
+        navigate(-1)
+    } else {
+       addGoal(data)
+       setSuccessMessage(t("messages.goalCreated"))
+        navigate("/goals")
+    }
 
     reset()
     setSuccessOpen(true)
@@ -79,7 +91,7 @@ export default function GoalForm({ defaultValues }) {
             severity="success"
             variant="filled"
           >
-            {t("messages.goalCreated")}
+            {successMessage}
           </Alert >
         </Snackbar>
 
@@ -166,13 +178,17 @@ export default function GoalForm({ defaultValues }) {
                 fullWidth
                 variant="contained"
                 disabled={!isValid}
-                startIcon={<CreateNewFolderIcon fontSize="small"  />}
+                startIcon={
+                   defaultValues
+                     ? <EditIcon fontSize="small"/>
+                     : <CreateNewFolderIcon fontSize="small"  />
+                  }
                 sx={{
                   py: 1.4,
                   textTransform: "none",
                 }}
               >
-                {t("buttons.create")}
+                {defaultValues ? t("buttons.update") : t("buttons.create")}
               </Button>
             </Grid>
           </Grid>

--- a/src/i18n/locales/en/createGoal.json
+++ b/src/i18n/locales/en/createGoal.json
@@ -30,11 +30,15 @@
   ],
 
   "buttons": {
-    "create": "Create Goal"
+    "create": "Create Goal",
+    "edit": "Edit",
+    "update": "Update"
   },
 
   "messages": {
-    "goalCreated": "Goal created successfully"
+    "goalCreated": "Goal created successfully",
+    "goalUpdated": "Goal updated successfully!",
+    "goalNotFound": "Goal not found"
   },
 
   "errors": {

--- a/src/i18n/locales/fa/createGoal.json
+++ b/src/i18n/locales/fa/createGoal.json
@@ -30,11 +30,15 @@
   ],
 
   "buttons": {
-    "create": "ایجاد هدف"
+    "create": "ایجاد هدف",
+    "edit": "ویرایش",
+    "update": "بروزرسانی"
   },
 
   "messages": {
-    "goalCreated": "هدف با موفقیت ایجاد شد"
+    "goalCreated": "هدف با موفقیت ایجاد شد",
+    "goalUpdated": "هدف با موفقیت بروزرسانی شد",
+    "goalNotFound": "هدف پیدا نشد "
   },
 
   "errors": {

--- a/src/pages/EditGoalPage.jsx
+++ b/src/pages/EditGoalPage.jsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router"
+import GoalForm from "../components/forms/GoalForm"
+import { useGoals } from "../context/GoalsContext"
+
+export default function EditGoalPage() {
+    const { id } = useParams()
+    const { goals } = useGoals()
+
+   const goal = goals.find(g => g.id === Number(id))
+
+    if(!goal) return <div>{t("messages.goalNotFound")}</div>
+
+    return (
+        <GoalForm defaultValues={goal}/>
+    )
+}

--- a/src/pages/GoalListPage.jsx
+++ b/src/pages/GoalListPage.jsx
@@ -3,15 +3,17 @@ import GoalCard from "../components/GoalCard";
 import GoalControl from "../components/GoalControls";
 import GoalList from "../components/GoalList";
 import { useGoals } from "../context/GoalsContext";
+import { useNavigate } from "react-router-dom";
 
 export default function GoalLists() {
+  const navigate = useNavigate()
   const { goals, removeGoal, updateGoal } = useGoals();
   const [filtertabs, setFilterTabs] = useState(0);
   const [searchText, setSearchText] = useState("");
   const [sortOption, setSortOption] = useState("newest");
   
-  function handleEdit(id, updateData) {
-    updateGoal(id, updateData)
+  function handleEdit(id) {
+    navigate(`/goals/edit/${id}`)
   }
   
   function handleDelete(id) {

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -2,11 +2,13 @@ import { Route, Routes } from "react-router-dom";
 import Dashboard from "../pages/DashboardPage";
 import GoalLists from "../pages/GoalListPage";
 import CreateGoal from "../pages/CreateGoalPage";
+import EditGoalPage from "../pages/EditGoalPage";
 import GoalDetails from "../pages/GoalDetailsPage";
 import Categories from "../pages/CategoriesPage";
 import Settings from "../pages/SettingsPage";
 import NotFound from "../pages/NotFoundPage";
 import AppLayout from "../layout/AppLayout";
+
 
 export default function AppRoutes(){
     return(
@@ -15,6 +17,7 @@ export default function AppRoutes(){
             <Route path="/" element={<Dashboard/>}/>
             <Route path="/goals" element={<GoalLists/>}/>
             <Route path="/goals/new" element={<CreateGoal/>}/>
+            <Route path="/goals/edit/:id" element={<EditGoalPage />}/> 
             <Route path="/goals/:id" element={<GoalDetails/>}/>
             <Route path="/categories" element={<Categories/>}/>
             <Route path="/settings" element={<Settings/>}/>


### PR DESCRIPTION
This PR adds the Edit Goal page.

Changes:
- Added EditGoalPage in /pages and routes in /appRoutes
- Reused GoalForm for editing goals by using defaultValues
- Navigate goal/edit in goalListPage an d add key in map
- Added an id to goalCard for onEdit
- Add some keys on createGoal.json base on goalEditPage

closes #72