### PR TITLE
Fix: EditGoalPage now finds goals correctly by id

### DIFF
--- a/src/pages/EditGoalPage.jsx
+++ b/src/pages/EditGoalPage.jsx
@@ -1,12 +1,14 @@
 import { useParams } from "react-router"
 import GoalForm from "../components/forms/GoalForm"
 import { useGoals } from "../context/GoalsContext"
+import { useTranslation } from "react-i18next"
 
 export default function EditGoalPage() {
+    const { t } = useTranslation()
     const { id } = useParams()
     const { goals } = useGoals()
 
-   const goal = goals.find(g => g.id === Number(id))
+    const goal = goals.find(g => String(g.id) === id)  // ← اصلاح شد
 
     if(!goal) return <div>{t("messages.goalNotFound")}</div>
 


### PR DESCRIPTION

Quick fix: the edit page was showing "Goal not found" sometimes. Turns out the ID comparison was a bit off (number vs string). Now it’s fixed and goals load correctly when clicking edit. 

Everything else works the same, no other changes. 

closes #85 