### PR TITLE
fix/goal-card-navigation

### DIFF
--- a/src/pages/GoalListPage.jsx
+++ b/src/pages/GoalListPage.jsx
@@ -50,6 +50,10 @@ export default function GoalLists() {
     updateGoal(id, updatedGoal);
   }
 
+  function handleOpenDetails(id) {
+    navigate(`/goals/${id}`)
+  }
+
   function handleAddProgress(id) {
     navigate(`/goals/${id}`);
   }
@@ -98,6 +102,7 @@ export default function GoalLists() {
         onDelete={handleDelete}
         onToggleStatus={handleToggleStatus}
         onAddProgress={handleAddProgress}
+        onOpenDetails={handleOpenDetails}
       />
     </>
   )


### PR DESCRIPTION
Fixes an issue where clicking a goal card caused a console error because the onOpenDetails prop was missing.

Added the handler in GoalListPage and passed it to GoalList so clicking a card now navigates to the goal details page.

closes #87 