### PR TITLE
Fix checkbox click navigation issue

### DIFF
--- a/src/components/GoalCard.jsx
+++ b/src/components/GoalCard.jsx
@@ -78,6 +78,7 @@ export default function GoalCard({
             <Checkbox
               checked={status === "completed"}
               sx={{ color, "&.Mui-checked": { color } }}
+              onClick={(e) => e.stopPropagation()}
               onChange={(e) => {
                 e.stopPropagation();
                 onToggleStatus(id);


### PR DESCRIPTION
Fixes an issue where clicking the checkbox also triggered navigation to the goal details page.

Added stopPropagation to prevent the event from bubbling up to the card click handler.

closes #102