### PR TITLE
feat: add confirm dialog for incomplete goals

### DIFF
--- a/src/components/dialog/ConfirmDialog.jsx
+++ b/src/components/dialog/ConfirmDialog.jsx
@@ -1,0 +1,29 @@
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@mui/material";
+
+export default function ConfirmDialog({
+    open,
+    onClose,
+    onConfirm,
+    title,
+}) {
+    const { t } = useTranslation("goalList");
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogContent>
+                <p>{t("confirmIncomplete")}</p>
+            </DialogContent>
+
+            <DialogActions>
+                <Button onClick={onClose}>
+                    {t("no")}
+                </Button>
+                <Button onClick={onConfirm} variant="contained" color="primary">
+                    {t("yes")}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}

--- a/src/i18n/locales/en/goalList.json
+++ b/src/i18n/locales/en/goalList.json
@@ -9,6 +9,7 @@
     "tabActive": "Active",
     "tabCompleted": "Completed",
     "tabStopped": "Stopped",
+    "confirmIncompleteTitle": "Incomplete Goal",
     "confirmIncomplete": "Are you sure? You haven't reached your goal yet.",
     "yes": "Yes",
     "no": "No"

--- a/src/i18n/locales/en/goalList.json
+++ b/src/i18n/locales/en/goalList.json
@@ -9,6 +9,7 @@
     "tabActive": "Active",
     "tabCompleted": "Completed",
     "tabStopped": "Stopped",
-    "confirmIncomplete": "Are you sure? You haven't reached your goal yet."
-  
+    "confirmIncomplete": "Are you sure? You haven't reached your goal yet.",
+    "yes": "Yes",
+    "no": "No"
 }

--- a/src/i18n/locales/fa/goalList.json
+++ b/src/i18n/locales/fa/goalList.json
@@ -9,6 +9,8 @@
     "tabActive": "فعال",
     "tabCompleted": "تکمیل شده",
     "tabStopped": "متوقف",
-    "confirmIncomplete": "آیا مطمئن هستید؟ هنوز به هدف خود نرسیده‌اید."
-  
+    "confirmIncomplete": "آیا مطمئن هستید؟ هنوز به هدف خود نرسیده‌اید.",
+    "yes": "بلی",
+    "no": "خیر"
 }
+  

--- a/src/i18n/locales/fa/goalList.json
+++ b/src/i18n/locales/fa/goalList.json
@@ -9,6 +9,7 @@
     "tabActive": "فعال",
     "tabCompleted": "تکمیل شده",
     "tabStopped": "متوقف",
+    "confirmIncompleteTitle": "هدف ناقص",
     "confirmIncomplete": "آیا مطمئن هستید؟ هنوز به هدف خود نرسیده‌اید.",
     "yes": "بلی",
     "no": "خیر"

--- a/src/pages/GoalListPage.jsx
+++ b/src/pages/GoalListPage.jsx
@@ -5,6 +5,8 @@ import { useGoals } from "../context/GoalsContext";
 import { useNavigate } from "react-router-dom";
 import useGoalCompletion from "../hooks/useGoalCompletion";
 import { useTranslation } from "react-i18next";
+import ConfirmDialog from "../components/dialog/ConfirmDialog";
+
 
 export default function GoalLists() {
   const { goals, removeGoal, updateGoal } = useGoals();
@@ -17,6 +19,9 @@ export default function GoalLists() {
   const [filtertabs, setFilterTabs] = useState(0);
   const [searchText, setSearchText] = useState("");
   const [sortOption, setSortOption] = useState("newest");
+
+  const [openConfirm, setOpenConfirm] = useState(false);
+  const [selectedId, setSelectedId] = useState(null);
 
   function handleEdit(id) {
     navigate(`/goals/edit/${id}`)
@@ -37,11 +42,10 @@ export default function GoalLists() {
 
     // for when not completed
     if (goal.progress < goal.target) {
-      const confirmComplete = window.confirm(
-        t("confirmIncomplete")
-      );
-
-      if (!confirmComplete) return;
+      setSelectedId(id)
+      setOpenConfirm(true);
+      return
+      
     }
 
 
@@ -104,6 +108,21 @@ export default function GoalLists() {
         onAddProgress={handleAddProgress}
         onOpenDetails={handleOpenDetails}
       />
+      
+      <ConfirmDialog
+  open={openConfirm}
+  title={t("confirmIncompleteTitle")} 
+  onClose={() => setOpenConfirm(false)}
+  onConfirm={() => {
+    if (selectedId !== null) {
+      const goal = goals.find(g => g.id === selectedId);
+      const updatedGoal = checkCompletion({ ...goal, status: "completed" });
+      updateGoal(selectedId, updatedGoal);
+    }
+    setOpenConfirm(false);
+    setSelectedId(null);
+  }}
+/>
     </>
   )
 


### PR DESCRIPTION
Added a confirm dialog when marking a goal as completed before reaching the target. 
- Provides a friendly warning to users.
- Supports dynamic translation for title and buttons (Yes/No).

closes #104
